### PR TITLE
Align HTML with app IDs and add controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,23 +10,30 @@
   <div class="app">
     <aside class="sidebar">
       <div class="section">
-        <div class="section-title">Patterns</div>
-        <div id="patterns" class="thumb-grid"></div>
+        <div class="section-title">Tile palette</div>
+        <div id="tilePalette" class="thumb-grid"></div>
       </div>
       <div class="section">
-        <div class="section-title">Colors</div>
-        <div id="colors" class="thumb-grid"></div>
+        <div class="section-title">Color palette</div>
+        <div id="colorPalette" class="thumb-grid"></div>
+      </div>
+      <div class="section">
+        <div class="section-title">Usage</div>
+        <div id="usage"></div>
       </div>
     </aside>
 
     <main class="stage-wrap">
       <div class="toolbar">
         <div class="left">
+          <button id="rotateBtn" class="btn">Rotate</button>
           <button id="undoBtn" class="btn">Undo</button>
-          <button id="redoBtn" class="btn">Redo</button>
-          <button id="clearBtn" class="btn danger">Clear</button>
+          <button id="resetBtn" class="btn danger">Reset</button>
         </div>
         <div class="right">
+          <button id="exportJson" class="btn">Export JSON</button>
+          <button id="exportPng" class="btn">Export PNG</button>
+          <button id="downloadLog" class="btn">Download Log</button>
           <label class="ctrl">Cell
             <input id="cellSize" type="range" min="60" max="180" value="120" />
           </label>
@@ -40,7 +47,7 @@
       </div>
 
       <div id="stage" class="stage">
-        <div id="grid" class="grid"></div>
+        <svg id="grid"></svg>
         <!-- sem renderuje tvoj JS dlaždice -->
       </div>
     </main>


### PR DESCRIPTION
## Summary
- Rename pattern/color containers to `tilePalette` and `colorPalette`
- Replace grid `<div>` with `<svg>` and add usage panel
- Add rotate/reset/export/log buttons in toolbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a828f1ce948333840a55bbb6f38455