### PR TITLE
fix(ui): align HTML↔JS IDs + DOMContentLoaded

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,11 @@
     <aside class="sidebar">
       <div class="section">
         <div class="section-title">Tile palette</div>
-        <div id="tilePalette" class="thumb-grid"></div>
+        <div id="patterns" class="thumb-grid"></div>
       </div>
       <div class="section">
         <div class="section-title">Color palette</div>
-        <div id="colorPalette" class="thumb-grid"></div>
+        <div id="colors" class="thumb-grid"></div>
       </div>
       <div class="section">
         <div class="section-title">Usage</div>
@@ -26,9 +26,10 @@
     <main class="stage-wrap">
       <div class="toolbar">
         <div class="left">
+          <button id="sidebarToggle" class="btn">☰</button>
           <button id="rotateBtn" class="btn">Rotate</button>
           <button id="undoBtn" class="btn">Undo</button>
-          <button id="resetBtn" class="btn danger">Reset</button>
+          <button id="clearBtn" class="btn danger">Clear</button>
         </div>
         <div class="right">
           <button id="exportJson" class="btn">Export JSON</button>
@@ -43,8 +44,11 @@
           <label class="ctrl">Snap
             <input id="snapToggle" type="checkbox" checked />
           </label>
+          <div id="assetBadge" class="asset-badge">Tiles: 0 | Colors: 0</div>
         </div>
       </div>
+
+      <div id="assetBanner" class="asset-banner hidden">Assets not loaded – check IDs/JSON/paths</div>
 
       <div id="stage" class="stage">
         <svg id="grid"></svg>

--- a/public/styles.css
+++ b/public/styles.css
@@ -75,3 +75,22 @@ body{
 }
 .tile img, .tile canvas{width:100%; height:100%; object-fit:cover; display:block}
 .tile.dragging{ transform:scale(1.02) }
+
+/* small counter badge in toolbar */
+.asset-badge{
+  margin-left:12px; padding:4px 8px; font-size:12px; color:var(--muted);
+  border:1px solid var(--border); border-radius:8px; background:var(--panel-2);
+}
+
+/* hidden by default, shown when assets missing */
+.asset-banner{
+  background:var(--danger); color:var(--panel);
+  padding:8px 12px; border-radius:var(--radius); text-align:center;
+  margin-bottom:14px;
+}
+
+.hidden{display:none}
+
+/* collapse sidebar when toggled */
+.app.sidebar-collapsed{grid-template-columns:0 1fr}
+.app.sidebar-collapsed .sidebar{display:none}


### PR DESCRIPTION
## Summary
- adopt new #patterns/#colors palettes and #clearBtn with fallback to legacy IDs
- wait for DOMContentLoaded before bootstrapping and wire up sidebar toggle
- collapse sidebar via app.sidebar-collapsed class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a828637a088333941400cd9a4cba38