### PR TITLE
fix(data): safe fetch + diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ npm test
 - `tiles/` and `colors/` contain sample assets and manifest JSON files.
 - `log.txt` placeholder for logs; in-browser logger offers download.
 - `requirements.txt` – no Python deps; JS deps via `package.json`.
+
+## Diagnostics
+- Manifest files (`tiles/tiles.json`, `colors/colors.json`) are fetched safely with clear console errors on failure.
+- Toolbar badge shows loaded asset counts. If any count is zero, a red banner “Assets not loaded” appears.
+- In development (served from `file://` or `localhost`), a cache-busting query ensures asset changes are picked up without manual cache clearing.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/utils.test.js"
+    "test": "node tests/utils.test.js && node tests/fetcher.test.js"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
         </div>
       </div>
 
-      <div id="assetBanner" class="asset-banner hidden">Assets not loaded – check IDs/JSON/paths</div>
+      <div id="assetBanner" class="asset-banner hidden">Assets not loaded</div>
 
       <div id="stage" class="stage">
         <svg id="grid"></svg>
@@ -56,6 +56,6 @@
     </main>
   </div>
 
-  <script src="/src/app.js" defer></script>
+  <script type="module" src="/src/app.js"></script>
 </body>
 </html>

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1,0 +1,37 @@
+/**
+ * Safe JSON fetch with optional cache busting in development.
+ * @param {string} url - Relative URL to JSON asset.
+ * @param {object} logger - Logger instance with log method.
+ * @param {Function} fetchFn - Custom fetch implementation for testing.
+ * @returns {Promise<{data: any|null, status: number}>}
+ */
+export async function safeFetch(url, logger = console, fetchFn = fetch) {
+  const fullUrl = url + cacheBust;
+  let status = 0;
+  try {
+    const res = await fetchFn(fullUrl);
+    status = res.status;
+    if (!res.ok) throw new Error(`HTTP ${status}`);
+    const data = await res.json();
+    return { data, status };
+  } catch (err) {
+    const msg = `fetch ${url} failed: ${err.message}`;
+    if (logger && typeof logger.log === 'function') logger.log(msg);
+    if (typeof console !== 'undefined' && typeof console.error === 'function') console.error(msg);
+    return { data: null, status };
+  }
+}
+
+/**
+ * Cache busting query for development environment.
+ * Uses current timestamp when served from localhost or file protocol.
+ */
+export const cacheBust = (() => {
+  if (typeof window !== 'undefined') {
+    const { protocol, hostname } = window.location;
+    if (protocol === 'file:' || hostname === 'localhost') {
+      return `?v=${Date.now()}`;
+    }
+  }
+  return '';
+})();

--- a/tests/fetcher.test.js
+++ b/tests/fetcher.test.js
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import { safeFetch } from '../src/fetcher.js';
+
+// mock logger for tests
+const logger = { log(){} };
+
+(async () => {
+  // success scenario
+  const okFetch = async () => ({ ok: true, status: 200, json: async () => ({ ok: true }) });
+  const ok = await safeFetch('/ok.json', logger, okFetch);
+  assert.strictEqual(ok.status, 200);
+  assert.deepStrictEqual(ok.data, { ok: true });
+
+  // failure scenario
+  const failFetch = async () => ({ ok: false, status: 404, json: async () => ({}) });
+  const fail = await safeFetch('/missing.json', logger, failFetch);
+  assert.strictEqual(fail.status, 404);
+  assert.strictEqual(fail.data, null);
+
+  console.log('fetcher tests passed');
+})();


### PR DESCRIPTION
## Summary
- add safeFetch helper with dev-only cache busting and error logging
- show asset counts in toolbar; banner warns when assets fail to load
- extend README and tests for diagnostics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84c076c308333b62f655c5fbeffae