### PR TITLE
feat(ui): responsive layout + mobile polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Simple in-browser editor for decorative panels.
 4. Export design via **Export JSON** or **Export PNG**.
 5. Download actions log with **Download Log**.
 
+On small screens use the **Menu** button to toggle the sidebar; layout adapts down to 640px.
+
 ## Development
 - TailwindCSS is loaded from CDN.
 - Grid utilities are in `src/utils.js`.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/utils.test.js && node tests/fetcher.test.js"
+    "test": "node tests/utils.test.js && node tests/fetcher.test.js && node tests/ui.test.js"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="app">
-    <aside class="sidebar">
+    <aside id="sidebar" class="sidebar">
       <div class="section">
         <div class="section-title">Tile palette</div>
         <div id="tilePalette" class="thumb-grid"></div>
@@ -26,6 +26,7 @@
     <main class="stage-wrap">
       <div class="toolbar">
         <div class="left">
+          <button id="sidebarToggle" class="btn">Menu</button>
           <button id="rotateBtn" class="btn">Rotate</button>
           <button id="undoBtn" class="btn">Undo</button>
           <button id="resetBtn" class="btn danger">Reset</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -16,6 +16,7 @@ html,body{height:100%}
 body{
   margin:0; background:linear-gradient(180deg,#0b0c10 0%, #0e1017 100%);
   color:var(--text); font:14px/1.4 system-ui, Segoe UI, Roboto, Arial, sans-serif;
+  overflow-x:hidden;
 }
 
 .app{display:grid; grid-template-columns:300px 1fr; height:100vh; gap:14px; padding:14px}
@@ -45,6 +46,7 @@ body{
   background:var(--panel); border:1px solid var(--border); border-radius:var(--radius);
   padding:10px 12px; margin-bottom:14px; box-shadow:var(--shadow)
 }
+#sidebarToggle{display:none}
 .btn{
   appearance:none; border:1px solid var(--border); background:var(--panel-2);
   color:var(--text); padding:8px 12px; border-radius:10px; cursor:pointer;
@@ -90,3 +92,28 @@ body{
 }
 
 .hidden{display:none}
+
+/* responsive tweaks */
+@media (max-width:1280px){
+  :root{--cell:110px}
+}
+@media (max-width:1100px){
+  :root{--cell:100px}
+}
+@media (max-width:900px){
+  :root{--cell:80px}
+  .app{grid-template-columns:1fr}
+  .sidebar{
+    position:fixed; left:0; top:0; bottom:0; width:260px;
+    transform:translateX(-100%); transition:transform .3s ease; z-index:100;
+  }
+  .sidebar.open{transform:translateX(0)}
+  #sidebarToggle{display:inline-block}
+  .thumb-grid{gap:14px}
+  .btn{padding:12px 16px}
+}
+@media (max-width:640px){
+  .thumb-grid{grid-template-columns:repeat(3,1fr)}
+  .btn{min-width:40px; min-height:40px; padding:10px}
+  .btn:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
+}

--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,7 @@ const gridSvg = document.getElementById('grid');
 const usageDiv = document.getElementById('usage');
 const assetBadge = document.getElementById('assetBadge');
 const assetBanner = document.getElementById('assetBanner');
+const sidebar = document.getElementById('sidebar');
 
 init();
 
@@ -153,6 +154,12 @@ function bindUI() {
   document.getElementById('exportJson').addEventListener('click', exportJson);
   document.getElementById('exportPng').addEventListener('click', exportPng);
   document.getElementById('downloadLog').addEventListener('click', () => logger.download());
+  // toggle sidebar for mobile view
+  const sidebarToggle = document.getElementById('sidebarToggle');
+  sidebarToggle.addEventListener('click', () => {
+    sidebar.classList.toggle('open');
+    logger.log('toggle sidebar');
+  });
 }
 
 /** Handle grid click to place tile */

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,0 +1,7 @@
+import fs from 'fs';
+import assert from 'assert';
+
+// basic check for sidebar toggle presence
+const html = fs.readFileSync('public/index.html', 'utf8');
+assert.ok(html.includes('id="sidebarToggle"'), 'sidebar toggle button missing');
+console.log('UI tests passed');


### PR DESCRIPTION
## Summary
- make sidebar toggleable via Menu button for narrow screens
- add responsive breakpoints for layout, grid, and controls
- ensure basic UI regression test for sidebar toggle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84f236ec08333b94442b5e80819dc