### PR TITLE
chore(server): static mapping + npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Run basic tests for utilities:
 npm test
 ```
 
+### Dev server
+Serve static assets with Express for local development:
+
+```bash
+npm start
+```
+
+The server exposes `public/` as the web root and maps `/src`, `/colors`, and `/tiles`. In development it disables caching (`Cache-Control: no-store`) and logs requests to `log.txt`.
+
 ## Structure
 - `tiles/` and `colors/` contain sample assets and manifest JSON files.
 - `log.txt` placeholder for logs; in-browser logger offers download.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/utils.test.js && node tests/fetcher.test.js && node tests/ui.test.js"
+    "test": "node tests/utils.test.js && node tests/fetcher.test.js && node tests/ui.test.js && node tests/server.test.js",
+    "start": "node server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,57 @@
+import { createServer } from 'http';
+import { promises as fs } from 'fs';
+import { extname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// Basic static file server with logging.
+// Serves public/ as root and maps /src, /colors, /tiles.
+const root = fileURLToPath(new URL('.', import.meta.url));
+const mappings = { '/src': 'src', '/colors': 'colors', '/tiles': 'tiles' };
+const isDev = process.env.NODE_ENV !== 'production';
+
+function mapPath(urlPath) {
+  for (const [prefix, dir] of Object.entries(mappings)) {
+    if (urlPath.startsWith(prefix)) {
+      return join(root, dir, urlPath.slice(prefix.length));
+    }
+  }
+  return join(root, 'public', urlPath);
+}
+
+function mime(ext) {
+  return {
+    '.js': 'text/javascript',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.html': 'text/html'
+  }[ext] || 'application/octet-stream';
+}
+
+function handler(req, res) {
+  const urlPath = new URL(req.url, 'http://localhost').pathname;
+  const filePath = mapPath(urlPath === '/' ? '/index.html' : urlPath);
+  fs.appendFile('log.txt', `${new Date().toISOString()} ${req.method} ${req.url}\n`, () => {});
+  fs.readFile(filePath)
+    .then(data => {
+      if (isDev) res.setHeader('Cache-Control', 'no-store');
+      res.statusCode = 200;
+      res.setHeader('Content-Type', mime(extname(filePath)));
+      res.end(data);
+    })
+    .catch(() => {
+      res.statusCode = 404;
+      res.end('Not found');
+    });
+}
+
+export function start(port = 3000) {
+  const server = createServer(handler);
+  return server.listen(port, () =>
+    console.log(`Server running at http://localhost:${port}`)
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  start();
+}

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,29 @@
+import assert from 'assert';
+import { start } from '../server.js';
+
+// verify static files are served
+(async () => {
+  const port = 3100;
+  const server = start(port);
+  const base = `http://localhost:${port}`;
+  try {
+    const resApp = await fetch(`${base}/src/app.js`);
+    assert.strictEqual(resApp.status, 200);
+
+    const resColors = await fetch(`${base}/colors/colors.json`);
+    assert.strictEqual(resColors.status, 200);
+
+    const resTiles = await fetch(`${base}/tiles/tiles.json`);
+    assert.strictEqual(resTiles.status, 200);
+
+    const resImg = await fetch(`${base}/colors/basic/red.png`);
+    assert.strictEqual(resImg.status, 200);
+
+    const resSvg = await fetch(`${base}/tiles/sample/1.svg`);
+    assert.strictEqual(resSvg.status, 200);
+
+    console.log('server tests passed');
+  } finally {
+    server.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- serve `public/` plus `/src`, `/colors`, and `/tiles` via a tiny HTTP server with request logging and dev cache busting
- add `npm start` for launching the server
- document and test server routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8509d472c83338a8710239ca0ed3f