### PR TITLE
feat(perf): lazy-load thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ npm start
 Open [http://localhost:3000](http://localhost:3000) in a browser.
 For dev updates use a hard refresh (`Ctrl+Shift+R`) to bypass cache.
 
+Thumbnails in side palettes are lazy-loaded for fewer initial requests and smoother scrolling on mobile.
+
 ## Structure
 
 - `public/` – `index.html` and other static assets

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/utils.test.js && node tests/fetcher.test.js && node tests/ui.test.js && node tests/controls.test.js && node tests/server.test.js && node tests/import.test.js",
+    "test": "node tests/utils.test.js && node tests/fetcher.test.js && node tests/ui.test.js && node tests/controls.test.js && node tests/server.test.js && node tests/import.test.js && node tests/lazyload.test.js",
     "start": "node server.js"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import { createGrid, placeTile, removeTile, serializeGrid, deserializeGrid } from './utils.js';
 import { Logger } from './logger.js';
 import { safeFetch, cacheBust } from './fetcher.js';
+import { observeLazyImages, PLACEHOLDER_SRC } from './lazy-loader.js';
 
 // Grid configuration
 const GRID_WIDTH = 8;
@@ -90,8 +91,9 @@ async function loadTiles() {
   for (const [collection, files] of Object.entries(data)) {
     for (const file of files) {
       const img = document.createElement('img');
-      img.src = `tiles/${collection}/${file}${cacheBust}`;
-      img.className = 'thumb';
+      img.src = PLACEHOLDER_SRC; // simple placeholder
+      img.dataset.src = `tiles/${collection}/${file}${cacheBust}`;
+      img.className = 'thumb skeleton';
       img.addEventListener('click', () => {
         activeTile = { collection, file };
         palette.querySelectorAll('.selected').forEach(el => el.classList.remove('selected'));
@@ -102,6 +104,7 @@ async function loadTiles() {
       count++;
     }
   }
+  observeLazyImages(palette, logger); // lazy load thumbnails
   return { status, count };
 }
 
@@ -122,8 +125,9 @@ async function loadColors() {
   for (const [paletteName, items] of Object.entries(data)) {
     for (const item of items) {
       const img = document.createElement('img');
-      img.src = `colors/${paletteName}/${item.file}${cacheBust}`;
-      img.className = 'thumb';
+      img.src = PLACEHOLDER_SRC; // simple placeholder
+      img.dataset.src = `colors/${paletteName}/${item.file}${cacheBust}`;
+      img.className = 'thumb skeleton';
       img.addEventListener('click', () => {
         activeColor = item.color;
         palette.querySelectorAll('.selected').forEach(el => el.classList.remove('selected'));
@@ -134,6 +138,7 @@ async function loadColors() {
       count++;
     }
   }
+  observeLazyImages(palette, logger); // lazy load thumbnails
   return { status, count };
 }
 

--- a/src/lazy-loader.js
+++ b/src/lazy-loader.js
@@ -1,0 +1,31 @@
+/**
+ * Observe images with data-src and load them when near viewport.
+ * Načíta obrázky až keď sú blízko vo viewporte.
+ * @param {HTMLElement} container - parent element containing lazy images
+ * @param {Logger} logger - logger for debug output
+ * @param {string} [rootMargin='150px'] - pre-load distance before entering view
+ */
+export function observeLazyImages(container, logger, rootMargin = '150px') {
+  const images = container.querySelectorAll('img[data-src]');
+  if (!images.length) return;
+
+  const observer = new IntersectionObserver(entries => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        const img = entry.target;
+        img.onload = () => img.classList.remove('skeleton');
+        img.src = img.dataset.src;
+        observer.unobserve(img);
+        if (logger && typeof logger.log === 'function') {
+          logger.log(`lazy load ${img.dataset.src}`);
+        }
+      }
+    }
+  }, { rootMargin, threshold: 0.1 });
+
+  images.forEach(img => observer.observe(img));
+}
+
+/** Transparent 1×1 PNG as placeholder */
+export const PLACEHOLDER_SRC =
+  'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=';

--- a/tests/lazyload.test.js
+++ b/tests/lazyload.test.js
@@ -1,0 +1,34 @@
+import assert from 'assert';
+import { observeLazyImages, PLACEHOLDER_SRC } from '../src/lazy-loader.js';
+
+// Minimal DOM-like stubs
+const img = {
+  dataset: { src: 'test.png' },
+  classList: {
+    classes: new Set(['thumb', 'skeleton']),
+    remove(cls) { this.classes.delete(cls); },
+    contains(cls) { return this.classes.has(cls); }
+  },
+  onload: null,
+  src: PLACEHOLDER_SRC
+};
+
+const container = { querySelectorAll: () => [img] };
+
+global.IntersectionObserver = class {
+  constructor(cb) { this.cb = cb; }
+  observe(el) {
+    this.cb([{ isIntersecting: true, target: el }], this);
+    if (typeof el.onload === 'function') el.onload();
+  }
+  unobserve() {}
+};
+
+const logger = { logs: [], log(msg) { this.logs.push(msg); } };
+observeLazyImages(container, logger);
+
+assert.equal(img.src, 'test.png');
+assert.ok(!img.classList.contains('skeleton'), 'skeleton not removed');
+assert.ok(logger.logs.some(l => l.includes('test.png')), 'logger missing entry');
+
+console.log('lazy load tests passed');


### PR DESCRIPTION
## Summary
- load tile and color thumbnails lazily to reduce initial requests
- track thumbnail loads and remove placeholders once visible
- add test coverage for lazy loading helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a85bf336b083339a1fbe39d122b40d