### PR TITLE
feat(a11y): labels + focus + keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ Run tests with:
 ```bash
 npm test
 ```
+
+## Accessibility
+
+- Buttons include `aria-label` attributes for screen readers.
+- Interactive elements show a visible focus ring.
+- Tile and color thumbnails can be selected via keyboard (Enter or Space).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/utils.test.js && node tests/fetcher.test.js && node tests/ui.test.js && node tests/controls.test.js && node tests/server.test.js && node tests/import.test.js && node tests/lazyload.test.js",
+    "test": "node tests/utils.test.js && node tests/fetcher.test.js && node tests/ui.test.js && node tests/controls.test.js && node tests/server.test.js && node tests/import.test.js && node tests/lazyload.test.js && node tests/a11y.test.js",
     "start": "node server.js"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -26,22 +26,22 @@
     <main class="stage-wrap">
       <div class="toolbar">
         <div class="left">
-          <button id="sidebarToggle" class="btn">Menu</button>
-          <button id="rotateBtn" class="btn">Rotate</button>
-          <button id="undoBtn" class="btn">Undo</button>
-          <button id="clearBtn" class="btn danger">Clear</button>
+          <button id="sidebarToggle" class="btn" aria-label="Toggle menu">Menu</button>
+          <button id="rotateBtn" class="btn" aria-label="Rotate tile">Rotate</button>
+          <button id="undoBtn" class="btn" aria-label="Undo last action">Undo</button>
+          <button id="clearBtn" class="btn danger" aria-label="Clear grid">Clear</button>
         </div>
         <div class="right">
-          <button id="importJson" class="btn">Import JSON</button>
-          <button id="exportJson" class="btn">Export JSON</button>
+          <button id="importJson" class="btn" aria-label="Import design from JSON">Import JSON</button>
+          <button id="exportJson" class="btn" aria-label="Export design as JSON">Export JSON</button>
           <label class="ctrl">Scale
             <select id="pngScale">
               <option value="1">1×</option>
               <option value="2">2×</option>
             </select>
           </label>
-          <button id="exportPng" class="btn">Export PNG</button>
-          <button id="downloadLog" class="btn">Download Log</button>
+          <button id="exportPng" class="btn" aria-label="Export design as PNG">Export PNG</button>
+          <button id="downloadLog" class="btn" aria-label="Download log file">Download Log</button>
           <label class="ctrl">Cell
             <input id="cellSize" type="range" min="60" max="180" value="120" />
           </label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -54,6 +54,12 @@ body{
   color:var(--text); padding:8px 12px; border-radius:10px; cursor:pointer;
   transition:background .12s ease, transform .06s ease;
 }
+.btn:focus-visible,
+.thumb:focus-visible,
+.ctrl select:focus-visible,
+.ctrl input:focus-visible {
+  outline:2px solid var(--accent); outline-offset:2px;
+}
 .btn:hover{ background:#1b1e2a } .btn:active{ transform:translateY(1px) }
 .btn.danger{ border-color:#45292b; background:#281214 } .btn.danger:hover{ background:#36181b }
 .ctrl{display:inline-flex; align-items:center; gap:8px; margin-left:12px; color:var(--muted)}
@@ -124,5 +130,4 @@ body{
 @media (max-width:640px){
   .thumb-grid{grid-template-columns:repeat(3,1fr)}
   .btn{min-width:40px; min-height:40px; padding:10px}
-  .btn:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
 }

--- a/src/app.js
+++ b/src/app.js
@@ -94,11 +94,21 @@ async function loadTiles() {
       img.src = PLACEHOLDER_SRC; // simple placeholder
       img.dataset.src = `tiles/${collection}/${file}${cacheBust}`;
       img.className = 'thumb skeleton';
-      img.addEventListener('click', () => {
+      img.alt = `${collection} ${file}`;
+      img.tabIndex = 0;
+      // select tile and mark as active
+      const selectTile = () => {
         activeTile = { collection, file };
         palette.querySelectorAll('.selected').forEach(el => el.classList.remove('selected'));
         img.classList.add('selected');
         logger.log(`select tile ${collection}/${file}`);
+      };
+      img.addEventListener('click', selectTile);
+      img.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          selectTile();
+        }
       });
       palette.appendChild(img);
       count++;
@@ -128,11 +138,21 @@ async function loadColors() {
       img.src = PLACEHOLDER_SRC; // simple placeholder
       img.dataset.src = `colors/${paletteName}/${item.file}${cacheBust}`;
       img.className = 'thumb skeleton';
-      img.addEventListener('click', () => {
+      img.alt = item.name;
+      img.tabIndex = 0;
+      // select color and mark as active
+      const selectColor = () => {
         activeColor = item.color;
         palette.querySelectorAll('.selected').forEach(el => el.classList.remove('selected'));
         img.classList.add('selected');
         logger.log(`select color ${item.name}`);
+      };
+      img.addEventListener('click', selectColor);
+      img.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          selectColor();
+        }
       });
       palette.appendChild(img);
       count++;

--- a/tests/a11y.test.js
+++ b/tests/a11y.test.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import assert from 'assert';
+
+// Ensure buttons have aria-label
+const html = fs.readFileSync('public/index.html', 'utf8');
+['sidebarToggle','rotateBtn','undoBtn','clearBtn','importJson','exportJson','exportPng','downloadLog'].forEach(id => {
+  const regex = new RegExp(`<button[^>]*id="${id}"[^>]*aria-label=`);
+  assert.ok(regex.test(html), `${id} missing aria-label`);
+});
+
+// Focus ring rules
+const css = fs.readFileSync('public/styles.css', 'utf8');
+assert.ok(css.includes('.btn:focus-visible'), 'focus ring rule for buttons missing');
+assert.ok(css.includes('.thumb:focus-visible'), 'focus ring rule for thumbs missing');
+
+// Thumbnails keyboard accessibility
+const js = fs.readFileSync('src/app.js', 'utf8');
+assert.ok(js.includes('tabIndex = 0'), 'thumbnails missing tabIndex');
+assert.ok(js.includes("e.key === 'Enter'") && js.includes("e.key === ' '"), 'keyboard handlers missing');
+
+console.log('A11Y tests passed');


### PR DESCRIPTION
## Summary
- add ARIA labels to toolbar buttons for screen readers
- show accent outline on focused buttons, thumbnails and controls
- enable keyboard selection of tile/color thumbnails and cover with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a85d0429e08333a40667c7204fa63b